### PR TITLE
Exclude nested project files to fix duplicate top-level statements

### DIFF
--- a/TrainingTrackerApi/TrainingTrackerApi.csproj
+++ b/TrainingTrackerApi/TrainingTrackerApi.csproj
@@ -20,4 +20,10 @@
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.2" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Remove="TrainingTrackerApi/**/*.cs" />
+    <Content Remove="TrainingTrackerApi/**" />
+    <None Remove="TrainingTrackerApi/**" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
### Motivation
- The root project was including files from a nested `TrainingTrackerApi/` directory (including a second `Program.cs` with top-level statements), which caused the "only one compilation unit can have top-level statements" build error.

### Description
- Updated `TrainingTrackerApi/TrainingTrackerApi.csproj` to remove `TrainingTrackerApi/**` from `Compile`, `Content`, and `None` item groups so the nested project's files are excluded from the outer project build.

### Testing
- Attempted to run `dotnet build TrainingTrackerApi.slnx`, but the environment does not have the `dotnet` CLI installed so the build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b9e5c013c8323a64ec53859bf2d26)