### PR TITLE
Enable Swagger UI at application root

### DIFF
--- a/TrainingTrackerApi/Program.cs
+++ b/TrainingTrackerApi/Program.cs
@@ -26,11 +26,12 @@ builder.Services.AddScoped<ITrainingWeekService, TrainingWeekService>();
 
 var app = builder.Build();
 
-if (app.Environment.IsDevelopment())
+app.UseSwagger();
+app.UseSwaggerUI(options =>
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
+    options.SwaggerEndpoint("/swagger/v1/swagger.json", "TrainingTracker API v1");
+    options.RoutePrefix = string.Empty;
+});
 
 app.UseHttpsRedirection();
 app.MapControllers();


### PR DESCRIPTION
### Motivation
- Expose Swagger/OpenAPI UI at the application root so endpoints can be explored and executed from the browser without being limited to the `Development` environment.

### Description
- Always register Swagger middleware in `TrainingTrackerApi/Program.cs` by calling `app.UseSwagger()` and `app.UseSwaggerUI(...)` and configure the UI to use `/swagger/v1/swagger.json` with `RoutePrefix` set to an empty string so the UI is served at `/`.

### Testing
- Attempted `dotnet build TrainingTrackerApi.slnx` in the environment and the build could not be run because the `dotnet` runtime/SDK is not installed in this execution environment (build not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69945115cc008323b845807f0fcd508c)